### PR TITLE
Some random improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "license": "MIT",
   "main": "src/index.js",
   "module": "src/main.js",
+  "bin": {
+    "lorena": "./src/terminal.js"
+  },
   "scripts": {
     "coverage": "nyc npm run mocha && nyc report --reporter=html",
     "coveralls": "nyc npm run mocha && nyc report --reporter=text-lcov | coveralls",

--- a/src/main.js
+++ b/src/main.js
@@ -155,12 +155,16 @@ export default class Lorena extends EventEmitter {
    * @returns {Promise} Promise with the result
    */
   oneMsg (msg) {
-    return new Promise((resolve) => {
-      this.once(msg, (data) => {
-        resolve(data)
-      })
-      // TODO: Add a timeout and reject.
-    })
+    return Promise.race(
+      [
+        new Promise((resolve) => {
+          this.once(msg, (data) => {
+            resolve(data)
+          })
+        }),
+        new Promise((resolve, reject) => setTimeout(() => reject(new Error('timeout')), 5000))
+      ]
+    )
   }
 
   /**

--- a/src/terminal.js
+++ b/src/terminal.js
@@ -17,70 +17,96 @@ const callRecipe = (recipe, thread, payload = {}) => {
 
 term.magenta('Lorena ^+Client^\n')
 const terminal = async () => {
-  let input, list, info
+  let input
   const history = []
   const autoComplete = ['ping', 'ping-remote', 'contact-list', 'exit', 'help', 'contact-add', 'contact-info']
 
-  while (true) {
-    term.magenta('lorena# ')
-    input = await term.inputField({ history: history, autoComplete: autoComplete, autoCompleteMenu: true }).promise
-    term.magenta('\n')
-    switch (input) {
-      case 'help':
-        term.gray('actions :\n')
-        console.log(autoComplete)
-        break
-      case 'ping':
-        term.gray('ping...')
-        callRecipe('ping', 'pong')
+  term.magenta('lorena# ')
+  term.on('key', function (name, matches, data) {
+    if (name === 'CTRL_C') {
+      term.grabInput(false)
+      setTimeout(function () { process.exit() }, 100)
+    }
+  })
+  input = await term.inputField({ history: history, autoComplete: autoComplete, autoCompleteMenu: true }).promise
+  term.magenta('\n')
+  switch (input) {
+    case 'help':
+      term.gray('actions :\n')
+      console.log(autoComplete)
+      break
+    case 'ping':
+      term.gray('ping...')
+      callRecipe('ping', 'pong')
+      try {
         await lorena.oneMsg('message:pong')
         term('^+pong^\n')
-        break
-      case 'ping-remote':
-        term.gray('DID : ')
-        input = await term.inputField().promise
-        term.gray('\nping remote...')
-        callRecipe('ping-remote', 'pong', { did: input })
+      } catch (error) {
+        term.gray(`^+${error.message}^\n`)
+      }
+      break
+    case 'ping-remote':
+      term.gray('DID : ')
+      input = await term.inputField().promise
+      term.gray('\nping remote...')
+      callRecipe('ping-remote', 'pong', { did: input })
+      try {
         await lorena.oneMsg('message:pong')
         term('^+pong^\n')
-        break
-      case 'contact-list':
-        term.gray('getting list...')
-        callRecipe('contact-list', 'list')
-        list = await lorena.oneMsg('message:list')
+      } catch (error) {
+        term.gray(`^+${error.message}^\n`)
+      }
+      break
+    case 'contact-list':
+      term.gray('getting list...')
+      callRecipe('contact-list', 'list')
+      try {
+        const list = await lorena.oneMsg('message:list')
         term('^+done^\n')
         console.log(list)
-        break
-      case 'contact-info':
-        term.gray('DID : ')
-        input = await term.inputField().promise
-        term.gray('\ngetting info...')
-        callRecipe('contact-info', 'info', { did: input })
-        info = await lorena.oneMsg('message:info')
+      } catch (error) {
+        term.gray(`^+${error.message}^\n`)
+      }
+      break
+    case 'contact-info':
+      term.gray('DID : ')
+      input = await term.inputField().promise
+      term.gray('\ngetting info...')
+      callRecipe('contact-info', 'info', { did: input })
+      try {
+        const info = await lorena.oneMsg('message:info')
         term('^+done^\n')
         console.log(info.payload)
-        break
-      case 'contact-add':
-        term.gray('DID : ')
-        input = await term.inputField().promise
-        term.gray('\nContacting...')
-        callRecipe('contact-add', 'add', {
-          did: input,
-          matrix: '@' + input + ':matrix.caelumlabs.com'
-        })
+      } catch (error) {
+        term.gray(`^+${error.message}^\n`)
+      }
+      break
+    case 'contact-add':
+      term.gray('DID : ')
+      input = await term.inputField().promise
+      term.gray('\nContacting...')
+      callRecipe('contact-add', 'add', {
+        did: input,
+        matrix: '@' + input + ':matrix.caelumlabs.com'
+      })
+      try {
         await lorena.oneMsg('message:add')
         term('^+done^\n')
-        break
-      case 'exit':
-      case 'quit':
-      case 'q':
-        process.exit()
-    }
+      } catch (error) {
+        term.gray(`^+${error.message}^\n`)
+      }
+      break
+    case 'exit':
+    case 'quit':
+    case 'q':
+      process.exit()
   }
+  terminal()
 }
 const main = async () => {
   term.gray('Conecting to idspace...')
-  lorena.connect('5c7ca0ef4248e3a5-b987eb7a015b24d8-d81519de41ebdbba')
+  // lorena.connect('5c7ca0ef4248e3a5-b987eb7a015b24d8-d81519de41ebdbba')
+  lorena.connect('efd708e2b5dc1648-77326e5151d48bd7-138df632fd0de206')
 
   lorena.on('error', (e) => {
     console.log('ERROR!!', e)

--- a/src/terminal.js
+++ b/src/terminal.js
@@ -1,5 +1,7 @@
+#!/usr/bin/env node
+
 var term = require('terminal-kit').terminal
-const Lorena = require('../src/main.js').default
+const Lorena = require('../src/index.js').default
 const lorena = new Lorena()
 let threadId = 0
 


### PR DESCRIPTION
- Remove while loop
- Ctr+c to exit anytime
- 5000 milliseconds timeout
- Make lorena-cli executable

For development:
`npm link` to install globally, then can use `lorena` to execute terminal.js
This allow to use it with npx and use `lorena` when `npm install -g @lorena--ssi/lorena-cli`
